### PR TITLE
fixing typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ a gatsby theme for your Drupal content
 
 ## Installation
 
-`yarn add gatsby-source-drupal`
+`yarn add gatsby-theme-drupal`
 
 ## Setup
 


### PR DESCRIPTION
Fixes the installation command in the README.md file to point to correct plugin.