### PR TITLE
Fixing hardcoded localhost in nodeTemplate.js and a few formatting issues

### DIFF
--- a/gatsby-theme-drupal/src/templates/entityTemplate.js
+++ b/gatsby-theme-drupal/src/templates/entityTemplate.js
@@ -15,24 +15,24 @@ export default ({ pageContext: { node, nodeFields, nodeName } }) => {
   import { graphql } from 'gatsby';
 
   import Layout from '../components/Layout';
-  
+
   export default ({ data }) => (
     <Layout headerTitle='title'>
-      <h3>Page Template</h3>
+      <h3>${entity} Template</h3>
       {JSON.stringify(data)}
     </Layout>
   );
 
-  export query = graphql(\`
+  export query = graphql\`
   query($${entity}ID: String!)${decodeURIComponent(
     q.replace(`allNode${entity}`, `node${entity}(id: { eq: $${entity}ID })`)
-  )}\`)
+  )}\`
   `;
 
   const nodeCode = (q, entity) => `
   // Add these lines to your gatsby-node.js file
   const ${entity} = await graphql(\`{
-    allNodePage {
+    allNode${entity} {
       nodes {
         id
         path {
@@ -44,7 +44,7 @@ export default ({ pageContext: { node, nodeFields, nodeName } }) => {
   \`)
 
   const ${entity}Template = require.resolve(\`./src/templates/${entity}Template.js\`);
-  
+
   ${entity}.data.allNode${entity}.nodes.map(node => {
     createPage({
       path: node.path.alias,

--- a/gatsby-theme-drupal/src/templates/nodeTemplate.js
+++ b/gatsby-theme-drupal/src/templates/nodeTemplate.js
@@ -16,7 +16,7 @@ export default ({ pageContext: { element, nodeName, nodeFields } }) => (
     </p>
     <iframe
       title="graphiql"
-      src={`http://localhost:8000/___graphql?query=%7B%0A%20%20allNode${nodeName}(filter%3A%20%7Bid%3A%20%7Beq%3A%20%22${
+      src={`${window.location.origin}/___graphql?query=%7B%0A%20%20allNode${nodeName}(filter%3A%20%7Bid%3A%20%7Beq%3A%20%22${
         element.id
       }%22%7D%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&variables=&operationName=undefined`}
       height="800px"


### PR DESCRIPTION
### Changes

`entityTemplate.js`
* Changed the template name to include the current content type/page type on L21
* Updated the export to declare `const` to prevent issues with linting and for better readability on L26
* Changed the query to use the correct page type on L35
* Removed parentheses around template query that were causing the following error: `
Error: It appears like Gatsby is misconfigured. Gatsby related `graphql` calls are supposed to only be evaluated at compile time, and then compiled away. Unfortunately, something went wrong and the query was left in the compiled code.`

`nodeTemplate.js`
* Removing hardcoded localhost in query in place of dynamic
